### PR TITLE
Add return type in API contract

### DIFF
--- a/src/core/chain.ts
+++ b/src/core/chain.ts
@@ -16,17 +16,24 @@ function getLast(chain: Chain, condition: (chain: Chain) => boolean): Chain {
     }
 }
 
-function createChainItem() {
+function createChainItem(): () => Chain {
     const itemValue: Chain = {};
     const [item, setItem] = createSignal(itemValue);
     itemValue.setItem = setItem;
     return item;
 }
 
+type ChainedListResult = readonly [
+    () => SuppleNodeEffect, // ChainedList component
+    (component: SuppleChild) => void, // Push method
+    () => void, // Pop method
+    () => number, // Get size method
+];
+
 export function createChainedList<Props>({
     tag,
     attributes,
-}: { tag?: string; attributes?: Props & { children?: never } } = {}) {
+}: { tag?: string; attributes?: Props & { children?: never } } = {}): ChainedListResult {
     const [size, setSize] = createSignal(0);
 
     const root = createChainItem();

--- a/src/core/component.ts
+++ b/src/core/component.ts
@@ -73,7 +73,7 @@ function extractRealDOMComponents(component: DOMComponent): RealDOMComponent[] {
  * @param childrenGetter a function to get the children
  * @returns a flat array of resolved children
  */
-export function children(childrenGetter: () => SuppleNode | undefined) {
+export function children(childrenGetter: () => SuppleNode | undefined): () => RealDOMComponent[] {
     const [components, setComponents] = createSignal<RealDOMComponent[]>([], {
         equals: shallowArrayEqual,
     });
@@ -153,7 +153,7 @@ let contextNb = 0;
  */
 export function createContext(): Context<unknown>;
 export function createContext<T>(defaultValue: T): Context<T>;
-export function createContext<T>(defaultValue?: T) {
+export function createContext<T>(defaultValue?: T): Context<T | undefined> {
     contextNb++;
 
     const context = {
@@ -162,7 +162,10 @@ export function createContext<T>(defaultValue?: T) {
         defaultValue: defaultValue,
     };
 
-    function ContextProvider({ value, children }: Parameters<Context<T>["Provider"]>[0]): SuppleNodeEffect {
+    function ContextProvider({
+        value,
+        children,
+    }: Parameters<Context<T | undefined>["Provider"]>[0]): SuppleNodeEffect {
         return createMemo(() => {
             getOwner()!.contextsMap.set(context.id, value);
             return createDOMComponent(children ?? []);
@@ -183,7 +186,7 @@ export function createContext<T>(defaultValue?: T) {
  * @param context the context object returned from createContext
  * @returns the context value
  */
-export function useContext<T>(context: Context<T>) {
+export function useContext<T>(context: Context<T>): T {
     const owner = getOwner();
     return owner?.contextsMap?.has(context.id)
         ? (owner.contextsMap.get(context.id) as T)

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -27,7 +27,7 @@ const contextStack = [] as (TrackingContext<unknown> | null)[];
  *
  * @returns owner (TrackingContext)
  */
-export function getOwner() {
+export function getOwner(): TrackingContext<unknown> | null {
     if (contextStack.length > 0) {
         return contextStack[contextStack.length - 1];
     } else {
@@ -72,7 +72,7 @@ export function runEffectInContext<T>(
     return result;
 }
 
-export function createChildContext<T>(effect: (prev: T) => T, value?: T) {
+export function createChildContext<T>(effect: (prev: T) => T, value?: T): TrackingContext<T> {
     const execute = () => {
         // TODO: call cleanup before value is changed in signal.
         // When cleanup is called, the new value of the signal was set, and
@@ -117,7 +117,7 @@ export function createChildContext<T>(effect: (prev: T) => T, value?: T) {
  * @param context the tracking context to cleanup
  * @param dispose dispose of the current context (deactivate it)
  */
-export function cleanup<T>(context: TrackingContext<T>, dispose = false) {
+export function cleanup<T>(context: TrackingContext<T>, dispose = false): void {
     // Recursively dispose of the context and it's children,
     // while calling all cleanup functions.
     function disposeRec(ctx: TrackingContext<T>, dispose: boolean) {
@@ -150,7 +150,7 @@ export function cleanup<T>(context: TrackingContext<T>, dispose = false) {
  * @param effect the computation to run w/o tracking
  * @returns the result of the effect
  */
-export function untrack<T>(effect: () => T) {
+export function untrack<T>(effect: () => T): T {
     return runEffectInContext(null, effect, ForwardParameter.NOTHING);
 }
 
@@ -163,7 +163,7 @@ export function untrack<T>(effect: () => T) {
  * @param effect the computation, which will be called with dispose as parameter
  * @returns the result of the effect
  */
-export function createRoot<T>(effect: (dispose: () => void) => T) {
+export function createRoot<T>(effect: (dispose: () => void) => T): T {
     // Create an inactive context (which won't be notified) to
     // track children and dependent contexts
     const context: TrackingContext = {
@@ -191,7 +191,7 @@ export function createRoot<T>(effect: (dispose: () => void) => T) {
  * @param effect the effect to run
  * @returns the result of the effect
  */
-export function runWithOwner<T>(owner: TrackingContext<T>, effect: () => T) {
+export function runWithOwner<T>(owner: TrackingContext<T>, effect: () => T): T {
     return runEffectInContext(owner, effect, ForwardParameter.NOTHING);
 }
 
@@ -203,7 +203,7 @@ export function runWithOwner<T>(owner: TrackingContext<T>, effect: () => T) {
  *
  * @param runOnce the computation which runs once at startup
  */
-export function onMount(runOnce: () => void) {
+export function onMount(runOnce: () => void): void {
     queueMicrotask(() => untrack(runOnce));
 }
 
@@ -213,7 +213,7 @@ export function onMount(runOnce: () => void) {
  *
  * @param cleanup the cleanup function to run
  */
-export function onCleanup(cleanup: CleanupFunction) {
+export function onCleanup(cleanup: CleanupFunction): void {
     const context = getOwner();
     if (context) {
         context.cleanups.push(cleanup);
@@ -239,7 +239,7 @@ export function on<T, U>(
     deps: Accessor<T> | AccessorArray<T>,
     fn: (input: T, prevInput?: T, prevValue?: U) => U,
     options: { defer?: boolean } = {},
-) {
+): (prevValue?: U) => U | undefined {
     let defer = options?.defer ?? false;
     let prevInput: T | undefined;
     let input: T;

--- a/src/core/controls.tsx
+++ b/src/core/controls.tsx
@@ -8,6 +8,7 @@ import {
     DOMComponent,
     Ref,
     SuppleChild,
+    SuppleChildren,
     SuppleComponent,
     SuppleNode,
     SuppleNodeEffect,
@@ -18,7 +19,7 @@ type WhenCondition<T> = T | undefined | null | false;
 
 interface MatchProps<T> {
     when: ValueOrAccessor<WhenCondition<T>>;
-    children?: SuppleChild[] | [(item: T) => SuppleNode];
+    children?: SuppleChildren | [(item: T) => SuppleNode];
 }
 
 interface ShowProps<T> extends MatchProps<T> {
@@ -100,7 +101,7 @@ export function Show<T>(props: ShowProps<T>): SuppleNodeEffect {
 export function Switch(props: {
     keyed?: boolean;
     fallback?: SuppleChild;
-    children?: SuppleChild[];
+    children?: SuppleChildren;
 }): SuppleNodeEffect {
     const resolved = children(() => props.children);
 
@@ -166,7 +167,7 @@ export function Switch(props: {
  * @param when the condition to evaluate
  * @param children the children to display when the condition is truthy
  */
-export function Match<T>(props: MatchProps<T>) {
+export function Match<T>(props: MatchProps<T>): SuppleNodeEffect {
     // The Match component is returning a fake empty DOM Component
     // that is enriched with the Match props, so that this
     // component can be resolved with children() helper and analyzed
@@ -208,7 +209,7 @@ export function Dynamic<Props>({
 }: Props & {
     children?: any[];
     component: ValueOrAccessor<SuppleComponent<Props> | string | null | undefined>;
-}) {
+}): SuppleNodeEffect {
     const componentMemo = createMemo(() => toValue(component));
     return createMemo(() => {
         const comp = componentMemo();
@@ -244,8 +245,8 @@ export function Portal(props: {
     mount?: ValueOrAccessor<HTMLElement>;
     ref?: Ref<HTMLDivElement | undefined>;
     useShadow?: boolean;
-    children?: SuppleChild[];
-}) {
+    children?: SuppleChildren;
+}): SuppleNodeEffect {
     const parent = toValue(props.mount) ?? document.body;
     const dispose = render(() => {
         if (parent instanceof HTMLHeadElement) {

--- a/src/core/helper.ts
+++ b/src/core/helper.ts
@@ -7,7 +7,7 @@ export type Nested<T> = (T | Nested<T>)[];
  * Flatten children (developers may return an array containing nested arrays
  * and expect them to be flatten out in the rendering phase).
  */
-export function flatten<T>(nestedChildren: Nested<T>) {
+export function flatten<T>(nestedChildren: Nested<T>): T[] {
     const children: T[] = [];
     for (const c of nestedChildren) {
         if (Array.isArray(c)) {
@@ -33,12 +33,12 @@ export function flatten<T>(nestedChildren: Nested<T>) {
  * @param other the other value to compare
  * @returns true if the two values are equivalent, false otherwise
  */
-export function sameValueZero<T>(value: T, other: T) {
+export function sameValueZero<T>(value: T, other: T): boolean {
     // Uses the fact that NaN is the only value which is not equal to itself
     return value === other || (Number.isNaN(value) && Number.isNaN(other));
 }
 
-export function shallowArrayEqual<T>(first: T[], second: T[]) {
+export function shallowArrayEqual<T>(first: T[], second: T[]): boolean {
     return (
         first === second ||
         (first.length === second.length && first.every((v, i) => sameValueZero(v, second[i])))
@@ -55,7 +55,7 @@ export function toArray<T>(v: T | T[] | null | undefined): T[] {
     }
 }
 
-export function toValue<T>(target: ValueOrAccessor<T>) {
+export function toValue<T>(target: ValueOrAccessor<T>): T {
     return typeof target === "function" ? (target as () => T)() : target;
 }
 
@@ -73,7 +73,7 @@ const DEFAULT_LOG_LEVELS = {
     clock: LOG_LEVEL.INFO,
 };
 
-function logMessage(level: LOG_LEVEL, maxLogLevel: LOG_LEVEL) {
+function logMessage(level: LOG_LEVEL, maxLogLevel: LOG_LEVEL): (...args) => void {
     return (...args) => {
         if (level <= maxLogLevel) {
             console[LOG_LEVEL[level].toLowerCase()](...args);
@@ -81,7 +81,9 @@ function logMessage(level: LOG_LEVEL, maxLogLevel: LOG_LEVEL) {
     };
 }
 
-export function createLogger(scope: keyof typeof DEFAULT_LOG_LEVELS) {
+type Logger = { [P in Lowercase<keyof typeof LOG_LEVEL>]: (...args) => void };
+
+export function createLogger(scope: keyof typeof DEFAULT_LOG_LEVELS): Logger {
     const logLevel = DEFAULT_LOG_LEVELS[scope];
     return {
         error: logMessage(LOG_LEVEL.ERROR, logLevel),
@@ -92,6 +94,6 @@ export function createLogger(scope: keyof typeof DEFAULT_LOG_LEVELS) {
     };
 }
 
-export function randomInt(n: number) {
+export function randomInt(n: number): number {
     return Math.floor(Math.random() * n);
 }

--- a/src/core/iterators.ts
+++ b/src/core/iterators.ts
@@ -57,7 +57,7 @@ interface IndexProps<T> {
  *            - index is the position (a constant number) in the array
  * @returns a reactive fragment composed of mapped element of the iterator
  */
-export function Index<T>({ each, children, fallback, equals }: IndexProps<T>) {
+export function Index<T>({ each, children, fallback, equals }: IndexProps<T>): SuppleNodeEffect {
     const resolvedChildren = indexArray(
         each,
         (element, index) => createRenderEffect(() => children?.[0]?.(element, index) ?? null),
@@ -101,7 +101,7 @@ export function mapArray<T, U>(
     iterator: () => Iterable<T>,
     mapFn: (v: T, i: () => number) => U,
     equals?: (prev: T, next: T) => boolean,
-) {
+): () => U[] {
     // Define the finder function (either uses the provided equals function
     // or use default sameValueZero algorithm to compare underlying elements)
     const compare = equals ?? sameValueZero;
@@ -193,7 +193,7 @@ export function indexArray<T, U>(
     iterator: () => Iterable<T>,
     mapFn: (v: () => T, i: number) => U,
     equals?: false | ((prev: T, next: T) => boolean),
-) {
+): () => U[] {
     // The previous input & mapped lists
     let previousEntries = [] as IndexEntry<T, U>[];
     let previousMappedArray = [] as U[];
@@ -250,7 +250,7 @@ function listEquals<T, U>(
     previousEntries: Entry<T, U>[],
     nextList: T[],
     equals: (prev: T, next: T) => boolean,
-) {
+): boolean {
     return (
         nextList.length === previousEntries.length &&
         previousEntries.every((e, i) => e.element !== REMOVED && equals(e.element, nextList[i]))

--- a/src/core/jsx.ts
+++ b/src/core/jsx.ts
@@ -1,5 +1,5 @@
 import {
-    SuppleChild,
+    SuppleChildren,
     SuppleComponent,
     JSXElement,
     SuppleNodeEffect,
@@ -11,8 +11,8 @@ import { toValue } from "./helper";
 
 export function h<Props>(
     type: string | SuppleComponent<Props>,
-    props?: Props & { children?: SuppleChild[] },
-    ...children: SuppleChild[]
+    props?: Props & { children?: SuppleChildren },
+    ...children: SuppleChildren
 ): JSXElement<Props> {
     let altChildren = props?.children ?? children;
     if (!Array.isArray(altChildren)) {
@@ -49,7 +49,7 @@ export function h<Props>(
     }
 }
 
-export function Fragment({ children }: { children: SuppleChild[] }): SuppleNodeEffect {
+export function Fragment({ children }: { children: SuppleChildren }): SuppleNodeEffect {
     return () => children;
 }
 
@@ -81,7 +81,7 @@ function Input({
     ref?: Ref<HTMLInputElement | undefined>;
     value?: ValueOrAccessor<string>;
     oninput?: (e: InputElementInputEvent) => void;
-    children?: SuppleChild[];
+    children?: SuppleChildren;
     [x: string]: any;
 }): SuppleNodeEffect {
     let inputRef: HTMLInputElement | undefined;

--- a/src/core/resource.ts
+++ b/src/core/resource.ts
@@ -38,7 +38,7 @@ export function createResource<R, P>(
 export function createResource<R, P>(
     source: ValueOrAccessor<FetcherParameter<P>> | ((p: P) => R | Promise<R>),
     fetcher?: (p: P) => R | Promise<R>,
-) {
+): Resource<R, P> {
     const [params, fetch] = createResourceParams<R, P>(source, fetcher);
 
     let loaded = false;
@@ -123,7 +123,7 @@ export function createResource<R, P>(
     });
 
     return [
-        resource,
+        resource as Resource<R, P>[0],
         {
             mutate(r?: R) {
                 previousData = r;

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -1,3 +1,4 @@
+import { Accessor } from "./types";
 import { createMemo, createSignal } from "./reactivity";
 
 export interface ActionPayload<T> {
@@ -13,7 +14,10 @@ export function createReduxStore() {
     // TODO
 }
 
-export function createReduxSlice<T>(initialValue: T, reducers: Reducers<T>) {
+export function createReduxSlice<T>(
+    initialValue: T,
+    reducers: Reducers<T>,
+): readonly [Accessor<T>, (action: ActionPayload<any>) => void] {
     const [store, setStore] = createSignal(initialValue);
     const dispatch = function (action: ActionPayload<any>) {
         if (action.type in reducers) {
@@ -28,6 +32,6 @@ export function createReduxSelector<T, U>(
     fn: (src: T, prev: U) => U,
     value?: U,
     equals?: (a: U, b: U) => boolean,
-) {
+): Accessor<U> {
     return createMemo((prev) => fn(source(), prev), value, { equals });
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -2,13 +2,13 @@ export type JSXHTMLElement<Props> = {
     __kind: "html_element";
     type: string;
     props: Props;
-    children: SuppleChild[];
+    children: SuppleChildren;
 };
 export type JSXSuppleElement<Props> = {
     __kind: "supple_element";
     type: SuppleComponent<Props>;
     props: Props;
-    children: SuppleChild[];
+    children: SuppleChildren;
 };
 
 export type JSXElement<Props> = JSXHTMLElement<Props> | JSXSuppleElement<Props>;
@@ -37,12 +37,13 @@ export interface ProxyDOMComponent extends AbstractDOMComponent {
 
 export type DOMComponent = RealDOMComponent | ProxyDOMComponent | MultiDOMComponent;
 
-export type DOMContainer = DOMComponent | ((component: DOMComponent, previousNodes?: Node[]) => void) | null;
+export type DOMHandler = (component: DOMComponent, previousNodes?: Node[]) => void;
+export type DOMContainer = DOMComponent | DOMHandler | null;
 
 export type SuppleNode =
     | DOMComponent
     | JSXElement<any>
-    | SuppleChild[]
+    | SuppleChildren
     | string
     | number
     | bigint
@@ -51,16 +52,18 @@ export type SuppleNode =
 
 export type SuppleNodeEffect = () => SuppleNode;
 export type SuppleChild = SuppleNode | SuppleNodeEffect;
+export type SuppleChildren = SuppleChild[];
 
 export type SuppleComponent<Props> = (props: Props) => SuppleNodeEffect;
 
 export interface Context<T> {
     id: symbol;
-    Provider: (props: { value: T; children?: SuppleChild[] }) => SuppleNodeEffect;
+    Provider: (props: { value: T; children?: SuppleChildren }) => SuppleNodeEffect;
     defaultValue: T;
 }
 
 export type Accessor<T> = () => T;
+export type Setter<T> = (newState: T | ((prev: T) => T)) => T;
 
 // Transforms a tuple to a tuple of accessors in a way that allows generics
 // to be inferred (from solidjs implementation)

--- a/src/examples/Navigation.tsx
+++ b/src/examples/Navigation.tsx
@@ -9,7 +9,7 @@ import {
     createEffect,
     toValue,
     ValueOrAccessor,
-    SuppleChild,
+    SuppleChildren,
 } from "../core";
 
 import { Todo } from "./todo";
@@ -122,7 +122,7 @@ export default function Navigation() {
 
 interface LinkProps {
     href: ValueOrAccessor<string>;
-    children?: SuppleChild[];
+    children?: SuppleChildren;
 }
 
 function Link({ href, children }: LinkProps) {

--- a/src/tests/utils/types.ts
+++ b/src/tests/utils/types.ts
@@ -1,6 +1,6 @@
 import { queries } from "@testing-library/dom";
 import type { Queries, BoundFunctions, prettyFormat } from "@testing-library/dom";
-import { SuppleChild, SuppleComponent, TrackingContext } from "../../core";
+import { SuppleChildren, SuppleComponent, TrackingContext } from "../../core";
 
 export interface Ref {
     container?: HTMLElement;
@@ -11,7 +11,7 @@ export interface Options {
     container?: HTMLElement;
     baseElement?: HTMLElement;
     queries?: Queries & typeof queries;
-    wrapper?: SuppleComponent<{ children: SuppleChild[] }>;
+    wrapper?: SuppleComponent<{ children: SuppleChildren }>;
 }
 
 export type DebugFn = (
@@ -31,7 +31,7 @@ export type Result = BoundFunctions<typeof queries> & {
 export type RenderHookOptions<A extends any[]> =
     | {
           initialProps?: A;
-          wrapper?: SuppleComponent<{ children: SuppleChild[] }>;
+          wrapper?: SuppleComponent<{ children: SuppleChildren }>;
       }
     | A;
 


### PR DESCRIPTION
Providing return type helps making sure that API contract is correctly implemented and that no bugs are introduced in typing.