### PR TITLE
Fix extensions in released package

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -14,7 +14,7 @@ module.exports = {
             env: {
                 node: true,
             },
-            files: [".eslintrc.{js,cjs}"],
+            files: [".eslintrc.{js,cjs}", "scripts/**"],
             parserOptions: {
                 sourceType: "script",
             },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "supplejs",
   "description": "SuppleJS is a toy project to re-implement SolidJS from scratch",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": {
     "name": "Delphin Barraud"
   },


### PR DESCRIPTION
Having no extension can cause issue (https://github.com/delph123/supplejs-templates/issues/1).

Extensions are generated via regex after TS compilation phase. Using bundler like TSUP would work as well but also mess the files generated and make it more difficult to debug.